### PR TITLE
Don't run pygpgme check on windows

### DIFF
--- a/lib/facter/pygpgme.rb
+++ b/lib/facter/pygpgme.rb
@@ -2,7 +2,7 @@ Facter.add('pygpgme_installed') do
   setcode do
     os = Facter.value(:operatingsystem)
     case os.downcase
-    when /debian|ubuntu/
+    when /debian|ubuntu|windows/
       'true'
     else
       output = Facter::Core::Execution.exec('rpm -qa | grep pygpgme')


### PR DESCRIPTION
All Facter scripts end up being ran on all hosts, and this bombs out on Windows.