### PR TITLE
Beta

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,9 +22,7 @@ class packagecloud() {
     case $::operatingsystem {
       'debian',
       'ubuntu': {
-        package { 'apt-transport-https':
-          ensure => latest,
-        }
+        ensure_packages('apt-transport-https')
       }
       'RedHat',
       'redhat',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -66,7 +66,7 @@ define packagecloud::repo(
           repos    => "${component}",
           key      => {
             'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
-            'server' => 'packagecloud.io'
+            'server' => 'pgp.mit.edu'
           }
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
   "issues_url": "https://github.com/computology/computology-packagecloud/issues",
   "dependencies": [
     {
+      "name": "puppetlabs-apt",
+      "version_requirement": "2.2.1"
+    },
+    {
       "version_range": ">= 1.0.0",
       "name": "puppetlabs-stdlib"
     }


### PR DESCRIPTION
Refactored:
* using `ensure_packages( ... )` in place of `package{ ... }` type to avoid collisions with other modules using `apt-transport-https`
* using puppetlabs-apt module to manage Apt repo keys in place of running the apt-key command on each puppet run. 