### PR TITLE
This causes issues if it runs over and over

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -143,11 +143,11 @@ define packagecloud::repo(
           require => Exec["import_gpg_${normalized_name}"],
         }
 
-        exec { "yum_make_cache_${repo_name}":
-          command => "yum -q makecache -y --disablerepo='*' --enablerepo='${normalized_name}'",
-          path    => '/usr/bin',
-          require => File[$normalized_name],
-        }
+        #exec { "yum_make_cache_${repo_name}":
+        #  command => "yum -q makecache -y --disablerepo='*' --enablerepo='${normalized_name}'",
+        #  path    => '/usr/bin',
+        #  require => File[$normalized_name],
+        #}
       }
 
       default: {


### PR DESCRIPTION
Don't see the benefit of this running at setup time which causes puppet to run it every single time.  Either it should be limited to only run once, or just removed.