### PR TITLE
Refactor gem repo into defined type

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,8 @@
+fixtures:
+    symlinks:
+        packagecloud: "#{source_dir}"
+    repositories:
+      stdlib:
+        repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
+        ref: 4.3.2
+    forge_modules:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tmp/
 modules/
 .librarian/
+spec/fixtures/

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,41 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
-gem 'test-kitchen'
-gem 'serverspec'
-gem 'busser-serverspec'
-gem 'busser'
-gem 'psych'
-gem 'kitchen-vagrant'
-gem 'kitchen-puppet'
-gem 'puppet'
-gem 'librarian-puppet'
-gem 'puppet-lint'
+group :test do
+  if puppetversion = ENV['PUPPET_GEM_VERSION']
+    gem 'puppet', puppetversion, :require => false
+  else
+    gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.0'
+  end
+
+  # rspec must be v2 for ruby 1.8.7
+  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+    gem 'rspec', '~> 2.0'
+  end
+
+  gem 'rake'
+  gem 'puppet-lint'
+  gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'puppet-syntax'
+  gem 'puppetlabs_spec_helper'
+  gem 'simplecov'
+  gem 'metadata-json-lint'
+end
+
+group :development do
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'puppet-blacksmith'
+  gem 'guard-rake'
+end
+
+group :system_tests do
+  gem 'librarian-puppet'
+  gem 'test-kitchen'
+  gem 'serverspec'
+  gem 'busser-serverspec'
+  gem 'busser'
+  gem 'psych'
+  gem 'kitchen-vagrant'
+  gem 'kitchen-puppet'
+  gem 'vagrant-wrapper'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,64 +1,148 @@
+GIT
+  remote: https://github.com/rodjek/rspec-puppet.git
+  revision: 9eb2c6ffc7f2dd56e2a72ac4966482848ad148ba
+  specs:
+    rspec-puppet (2.3.2)
+      rspec
+
 GEM
-  remote: https://rubygems.org/
+  remote: http://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
-    activemodel (4.1.4)
-      activesupport (= 4.1.4)
+    activemodel (4.2.0)
+      activesupport (= 4.2.0)
       builder (~> 3.1)
-    activesupport (4.1.4)
-      i18n (~> 0.6, >= 0.6.9)
+    activesupport (4.2.0)
+      i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
+    backports (3.6.8)
     builder (3.2.2)
     busser (0.6.0)
       thor
     busser-serverspec (0.2.6)
       busser
+    coderay (1.1.1)
     diff-lcs (1.2.5)
-    facter (2.1.0)
+    docile (1.1.5)
+    domain_name (0.5.20160216)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.8.1)
+      ffi (>= 1.3.0)
+    facter (2.4.6)
       CFPropertyList (~> 2.2.6)
-    faraday (0.9.0)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    her (0.7.2)
-      activemodel (>= 3.0.0, < 4.2)
-      activesupport (>= 3.0.0, < 4.2)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.10)
+    formatador (0.2.5)
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-rake (1.0.0)
+      guard
+      rake
+    her (0.7.3)
+      activemodel (>= 3.0.0, <= 4.2)
+      activesupport (>= 3.0.0, <= 4.2)
       faraday (>= 0.8, < 1.0)
       multi_json (~> 1.7)
     hiera (1.3.4)
       json_pure
     highline (1.6.21)
-    i18n (0.6.11)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    i18n (0.7.0)
     json (1.8.1)
-    json_pure (1.8.1)
+    json_pure (1.8.3)
     kitchen-puppet (0.0.12)
     kitchen-vagrant (0.15.0)
       test-kitchen (~> 1.0)
-    librarian (0.1.2)
-      highline
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    librarian-puppet (2.2.1)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 1.0)
+      rsync
+    librarianp (0.6.3)
       thor (~> 0.15)
-    librarian-puppet (1.1.2)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    lumberjack (1.0.10)
+    metaclass (0.0.4)
+    metadata-json-lint (0.0.11)
       json
-      librarian (>= 0.1.2)
-      puppet_forge
-    minitest (5.4.0)
+      spdx-licenses (~> 1.0)
+    method_source (0.8.2)
+    mime-types (2.99.1)
+    minitest (5.8.4)
     mixlib-shellout (1.4.0)
-    multi_json (1.10.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
+    nenv (0.3.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
+    netrc (0.11.0)
+    notiffany (0.0.8)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     psych (2.0.5)
-    puppet (3.6.2)
+    puppet (3.8.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-      rgen (~> 0.6.5)
+    puppet-blacksmith (3.3.1)
+      puppet (>= 2.7.16)
+      rest-client
     puppet-lint (1.1.0)
-    puppet_forge (1.0.3)
+    puppet-syntax (2.1.0)
+      rake
+    puppet_forge (1.0.4)
       her (~> 0.6)
-    rgen (0.6.6)
+    puppetlabs_spec_helper (1.1.0)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    rake (10.5.0)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -70,6 +154,7 @@ GEM
       rspec-core (>= 2.99.0.beta1)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-mocks (2.99.1)
+    rsync (1.0.9)
     safe_yaml (1.0.3)
     serverspec (1.10.0)
       highline
@@ -77,6 +162,15 @@ GEM
       rspec (~> 2.99)
       rspec-its
       specinfra (~> 1.20)
+    shellany (0.0.1)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    slop (3.6.0)
+    spdx-licenses (1.0.0)
+      json
     specinfra (1.20.0)
     test-kitchen (1.2.1)
       mixlib-shellout (~> 1.2)
@@ -85,9 +179,27 @@ GEM
       safe_yaml (~> 1.0)
       thor (~> 0.18)
     thor (0.19.1)
-    thread_safe (0.3.4)
-    tzinfo (1.2.1)
+    thread_safe (0.3.5)
+    travis (1.8.2)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    travis-lint (2.0.0)
+      json
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    vagrant-wrapper (2.0.3)
+    websocket (1.2.2)
 
 PLATFORMS
   ruby
@@ -95,11 +207,22 @@ PLATFORMS
 DEPENDENCIES
   busser
   busser-serverspec
+  guard-rake
   kitchen-puppet
   kitchen-vagrant
   librarian-puppet
+  metadata-json-lint
   psych
-  puppet
+  puppet (~> 3.8.0)
+  puppet-blacksmith
   puppet-lint
+  puppet-syntax
+  puppetlabs_spec_helper
+  rake
+  rspec-puppet!
   serverspec
+  simplecov
   test-kitchen
+  travis
+  travis-lint
+  vagrant-wrapper

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,39 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+# These two gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+PuppetLint.configuration.fail_on_warnings
+PuppetLint.configuration.send('relative')
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/manifests/gem_repo.pp
+++ b/manifests/gem_repo.pp
@@ -1,0 +1,11 @@
+define packagecloud::gem_repo(
+  $base_url,
+  $repo_name,
+){
+
+  exec { "install packagecloud ${repo_name} repo as gem source":
+    command => "gem source --add ${base_url}/${repo_name}/",
+    unless  => "gem source --list | grep ${base_url}/${repo_name}",
+  }
+
+}

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -46,64 +46,74 @@ define packagecloud::repo(
     $base_url = $server_address
   }
 
-  if $type == 'gem' {
-    exec { "install packagecloud ${repo_name} repo as gem source":
-      command => "gem source --add ${base_url}/${repo_name}/",
-      unless  => "gem source --list | grep ${base_url}/${repo_name}",
-    }
-  } elsif $type == 'deb' {
-    $osname = downcase($::operatingsystem)
-    case $osname {
-      'debian', 'ubuntu': {
-
-        $component = 'main'
-        $repo_url = "${base_url}/${repo_name}/${osname}"
-        $distribution =  $::lsbdistcodename
-
-        file { $normalized_name:
-          ensure  => file,
-          path    => "/etc/apt/sources.list.d/${normalized_name}.list",
-          mode    => '0644',
-          content => template('packagecloud/apt.erb'),
-        }
-
-        exec { "apt_key_add_${normalized_name}":
-          command => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
-          path    => '/usr/bin/:/bin/',
-          require => File[$normalized_name],
-        }
-
-        exec { "apt_get_update_${normalized_name}":
-          command =>  "apt-get update -o Dir::Etc::sourcelist=\"sources.list.d/${normalized_name}.list\" -o Dir::Etc::sourceparts=\"-\" -o APT::Get::List-Cleanup=\"0\"",
-          path    => '/usr/bin/:/bin/',
-          require => Exec["apt_key_add_${normalized_name}"],
-        }
-      }
-
-      default: {
-        fail("Sorry, ${::operatingsystem} isn't supported for apt repos at this time. Email support@packagecloud.io")
+  case $type {
+    'gem': {
+      packagecloud::gem_repo {"Gem Repo ${repo_name}":
+        base_url  => $base_url,
+        repo_name => $repo_name,
       }
     }
-  } elsif $type == 'rpm' {
-    case $::operatingsystem {
-      'RedHat', 'redhat', 'CentOS', 'centos', 'Amazon', 'Fedora', 'Scientific', 'OracleLinux', 'OEL': {
+    'deb': {
+      $osname = downcase($::operatingsystem)
+      case $osname {
+        'debian', 'ubuntu': {
 
-        $majrel = $::osreleasemaj
-        if $::pygpgme_installed == 'false' {
-          warning('The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/stahnma/puppet-module-epel')
-          $repo_gpgcheck = 0
-        } else {
-          $repo_gpgcheck = 1
+          $component = 'main'
+          $repo_url = "${base_url}/${repo_name}/${osname}"
+          $distribution =  $::lsbdistcodename
+
+          file { $normalized_name:
+            ensure  => file,
+            path    => "/etc/apt/sources.list.d/${normalized_name}.list",
+            mode    => '0644',
+            content => template('packagecloud/apt.erb'),
+          }
+
+          exec { "apt_key_add_${normalized_name}":
+            command => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
+            path    => '/usr/bin/:/bin/',
+            require => File[$normalized_name],
+          }
+
+          exec { "apt_get_update_${normalized_name}":
+            command =>  "apt-get update -o Dir::Etc::sourcelist=\"sources.list.d/${normalized_name}.list\" -o Dir::Etc::sourceparts=\"-\" -o APT::Get::List-Cleanup=\"0\"",
+            path    => '/usr/bin/:/bin/',
+            require => Exec["apt_key_add_${normalized_name}"],
+          }
         }
+        default: {
+          fail("Sorry, ${::operatingsystem} isn't supported for apt repos at this time. Email support@packagecloud.io")
+        }
+      }
+    }
+    'rpm': {
+      case $::operatingsystem {
+        'RedHat', 'redhat', 'CentOS', 'centos', 'Amazon', 'Fedora', 'Scientific', 'OracleLinux', 'OEL': {
 
-        if $read_token {
-          if $majrel == '5' {
-            $yum_repo_url = $::operatingsystem ? {
-              /(RedHat|redhat|CentOS|centos)/ => "${server_address}/priv/${read_token}/${repo_name}/el/5/${::architecture}/",
-              /(OracleLinux|OEL)/ => "${server_address}/priv/${read_token}/${repo_name}/ol/5/${::architecture}/",
-              'Scientific' => "${server_address}/priv/${read_token}/${repo_name}/scientific/5/${::architecture}/",
+          $majrel = $::osreleasemaj
+          if $::pygpgme_installed == false {
+            warning('The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/stahnma/puppet-module-epel')
+            $repo_gpgcheck = 0
+          } else {
+            $repo_gpgcheck = 1
+          }
+
+          if $read_token {
+            if $majrel == '5' {
+              $yum_repo_url = $::operatingsystem ? {
+                /(RedHat|redhat|CentOS|centos)/ => "${server_address}/priv/${read_token}/${repo_name}/el/5/${::architecture}/",
+                /(OracleLinux|OEL)/ => "${server_address}/priv/${read_token}/${repo_name}/ol/5/${::architecture}/",
+                'Scientific' => "${server_address}/priv/${read_token}/${repo_name}/scientific/5/${::architecture}/",
+              }
+              $gpg_url = "${server_address}/priv/${read_token}/${repo_name}/gpgkey"
+            } else {
+              $yum_repo_url = $::operatingsystem ? {
+                /(RedHat|redhat|CentOS|centos)/ => "${base_url}/${repo_name}/el/${majrel}/${::architecture}/",
+                /(OracleLinux|OEL)/ => "${base_url}/${repo_name}/ol/${majrel}/${::architecture}/",
+                'Scientific' => "${base_url}/${repo_name}/scientific/${majrel}/${::architecture}/",
+              }
+              $gpg_url = "${base_url}/${repo_name}/gpgkey"
             }
-            $gpg_url = "${server_address}/priv/${read_token}/${repo_name}/gpgkey"
           } else {
             $yum_repo_url = $::operatingsystem ? {
               /(RedHat|redhat|CentOS|centos)/ => "${base_url}/${repo_name}/el/${majrel}/${::architecture}/",
@@ -112,39 +122,35 @@ define packagecloud::repo(
             }
             $gpg_url = "${base_url}/${repo_name}/gpgkey"
           }
-        } else {
-          $yum_repo_url = $::operatingsystem ? {
-            /(RedHat|redhat|CentOS|centos)/ => "${base_url}/${repo_name}/el/${majrel}/${::architecture}/",
-            /(OracleLinux|OEL)/ => "${base_url}/${repo_name}/ol/${majrel}/${::architecture}/",
-            'Scientific' => "${base_url}/${repo_name}/scientific/${majrel}/${::architecture}/",
+
+          $description = $normalized_name
+          $repo_url = $::operatingsystem ? {
+            /(RedHat|redhat|CentOS|centos|Scientific|OracleLinux|OEL)/ => $yum_repo_url,
+            'Fedora' => "${base_url}/${repo_name}/fedora/${majrel}/${::architecture}/",
+            'Amazon' => "${base_url}/${repo_name}/el/6/${::architecture}",
           }
-          $gpg_url = "${base_url}/${repo_name}/gpgkey"
+
+          file { $normalized_name:
+            ensure  => file,
+            path    => "/etc/yum.repos.d/${normalized_name}.repo",
+            mode    => '0644',
+            content => template('packagecloud/yum.erb'),
+          }
+
+          exec { "yum_make_cache_${repo_name}":
+            command => "yum -q makecache -y --disablerepo='*' --enablerepo='${normalized_name}'",
+            path    => '/usr/bin',
+            require => File[$normalized_name],
+          }
         }
 
-        $description = $normalized_name
-        $repo_url = $::operatingsystem ? {
-          /(RedHat|redhat|CentOS|centos|Scientific|OracleLinux|OEL)/ => $yum_repo_url,
-          'Fedora' => "${base_url}/${repo_name}/fedora/${majrel}/${::architecture}/",
-          'Amazon' => "${base_url}/${repo_name}/el/6/${::architecture}",
-        }
-
-        file { $normalized_name:
-          ensure  => file,
-          path    => "/etc/yum.repos.d/${normalized_name}.repo",
-          mode    => '0644',
-          content => template('packagecloud/yum.erb'),
-        }
-
-        exec { "yum_make_cache_${repo_name}":
-          command => "yum -q makecache -y --disablerepo='*' --enablerepo='${normalized_name}'",
-          path    => '/usr/bin',
-          require => File[$normalized_name],
+        default: {
+          fail("Sorry, ${::operatingsystem} isn't supported for yum repos at this time. Email support@packagecloud.io")
         }
       }
-
-      default: {
-        fail("Sorry, ${::operatingsystem} isn't supported for yum repos at this time. Email support@packagecloud.io")
-      }
+    }
+    default: {
+      fail("Sorry, ${type} isn't a supported repository type in this module right now. Email support@packagecloud.io")
     }
   }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -91,7 +91,7 @@ define packagecloud::repo(
         'RedHat', 'redhat', 'CentOS', 'centos', 'Amazon', 'Fedora', 'Scientific', 'OracleLinux', 'OEL': {
 
           $majrel = $::osreleasemaj
-          if $::pygpgme_installed == false {
+          if $::pygpgme_installed == 'false' {
             warning('The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/stahnma/puppet-module-epel')
             $repo_gpgcheck = 0
           } else {

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/defines/gem_repo_spec.rb
+++ b/spec/defines/gem_repo_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'packagecloud::gem_repo' do
+  let :pre_condition do
+    "Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }"
+  end
+
+  # add these two lines in a single test block to enable puppet and hiera debug mode
+  # Puppet::Util::Log.level = :debug
+  # Puppet::Util::Log.newdestination(:console)
+
+  context 'with sensible parameters' do
+    let(:title) { 'username/publicrepo' }
+
+    let(:params) do
+      {
+        :base_url => 'https://packagecloud.io',
+        :repo_name => 'username/publicrepo',
+      }
+    end
+    it do
+      is_expected.to compile.with_all_deps
+    end
+    it do
+      is_expected.to contain_exec('install packagecloud username/publicrepo repo as gem source').
+             with({"command"=>"gem source --add https://packagecloud.io/username/publicrepo/",
+                   "unless"=>"gem source --list | grep https://packagecloud.io/username/publicrepo"})
+    end
+    it do
+      is_expected.to create_packagecloud__gem_repo('username/publicrepo')
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,1 @@
-dir = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(dir, 'lib')
-
-require 'mocha'
-require 'puppet'
-require 'rspec'
-require 'spec/autorun'
-
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
-end
-
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
-end
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
Moves gem repo into new defined type

I'm going to refactor the others, but I thought I'd make the changes in manageable chunks

Also added working rspec tests for the new gem_repo defined type

I ran the test-kitchen tests and everything passed, so functionality is the same :+1: 