### PR TITLE
Changes to use top scoped class include

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -28,7 +28,7 @@ define packagecloud::repo(
   validate_string($type)
   validate_string($master_token)
 
-  include packagecloud
+  include ::packagecloud
 
   if $fq_name != undef {
     $repo_name = $fq_name


### PR DESCRIPTION
Puppet-lint rule fixed: class included by relative name on line 31