### PR TITLE
Change to use yumrepo type

### DIFF
--- a/templates/yum.erb
+++ b/templates/yum.erb
@@ -2,7 +2,7 @@
 # module 'packagecloud'
 
 [<%= @normalized_name %>]
-name=<%= @description %>
+name=<%= @normalized_name %>
 baseurl=<%= @repo_url %>
 repo_gpgcheck=<%= @repo_gpgcheck %>
 <% if @priority -%>


### PR DESCRIPTION
- ~~Replaces old file usage, so also removes template for yum~~
- ~~Changes yum makecache to be `refreshonly`  …~~
- ~~Only needs to run when yum repo changes~~
- ~~Fixes #19 (Now more idempotent!)~~
- Only when Puppet >= 3.6 (when the `repo_gpgcheck` parameter was added)
- Removes use of `$description` variable, as it was the same as `$normalised_name` so no need for a new variable`
