### PR TITLE
Use ensure_packages rather than forcing the installation of the dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,9 +22,7 @@ class packagecloud() {
     case $::operatingsystem {
       'debian',
       'ubuntu': {
-        package { 'apt-transport-https':
-          ensure => latest,
-        }
+        ensure_packages('apt-transport-https')
       }
       'RedHat',
       'redhat',
@@ -35,9 +33,7 @@ class packagecloud() {
       'Scientific',
       'OracleLinux',
       'OEL': {
-        package { 'pygpgme':
-          ensure => latest,
-        }
+        ensure_packages('pygpgme')
       }
       default: {
         fail("Sorry, ${::operatingsystem} isn't supported. Email support@packagecloud.io for help.")

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/computology/computology-packagecloud/issues",
   "dependencies": [
     {
-      "version_range": ">= 1.0.0",
+      "version_range": ">= 3.2.0",
       "name": "puppetlabs-stdlib"
     }
   ]


### PR DESCRIPTION
`ensure_packages` is the recommended way to install packages within modules. It avoids conflicts with other modules that might require the same packages.

This is an updated version of #18