### PR TITLE
Use the validate_legacy system (as puppet4 now supports types)

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -26,8 +26,8 @@ define packagecloud::repo(
   $metadata_expire = 300,
   $server_address = 'https://packagecloud.io',
 ) {
-  validate_string($type)
-  validate_string($master_token)
+  validate_legacy("Optional[String]", "validate_string", $type)
+  validate_legacy("Optional[String]", "validate_string", $master_token)
 
   include ::packagecloud
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/computology/computology-packagecloud/issues",
   "dependencies": [
     {
-      "version_range": ">= 1.0.0",
+      "version_range": ">= 4.13.0",
       "name": "puppetlabs-stdlib"
     }
   ]


### PR DESCRIPTION
Puppet4 now has proper typing support. Instead of moving the entire module to puppet4 (which would break Puppet3 users), let's get started with the legacy validation now supported by stdlib (which will remove warning messages)