### PR TITLE
Adds basic .travis.yml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+script: "bundle exec rake validate lint spec"
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 2.3.1
+    bundler_args: --without system_tests
+    env: PUPPET_GEM_VERSION="~> 4.0"
+notifications:
+  email: false


### PR DESCRIPTION
Travis has been enabled #33 but there's currently no .travis.yml

This is an extremely simple Travis config just to run syntax, specs and lint

It could be updated in the future to add in the kitchen-puppet acceptance tests, but this is a good first run.