### PR TITLE
optimize check for pygpgme

### DIFF
--- a/lib/facter/pygpgme.rb
+++ b/lib/facter/pygpgme.rb
@@ -5,8 +5,8 @@ Facter.add('pygpgme_installed') do
     when /debian|ubuntu|windows/
       'true'
     else
-      output = Facter::Core::Execution.exec('rpm -qa | grep pygpgme')
-      if !/^pygpgme.*/.match(output).nil?
+      output = Facter::Core::Execution.exec('rpm -q pygpgme')
+      if !/^pygpgme-.*/.match(output).nil?
         'true'
       else
         'false'


### PR DESCRIPTION
We were doing some profiling to troubleshoot slow puppet runs and noticed that this fact was taking longer than we'd expect.  This change speeds it up by only checking for the `pygpgme` package

```bash
[root@389f9a260f7a /]$ time (rpm -qa |grep pygpgme)  
pygpgme-0.3-9.el7.x86_64

real	0m0.867s
user	0m0.135s
sys	0m0.065s
```

```bash
[root@389f9a260f7a /]$ time (rpm -q pygpgme)  
pygpgme-0.3-9.el7.x86_64

real	0m0.033s
user	0m0.024s
sys	0m0.009s
```

```bash
[root@6f1cf2b76513 /]$ rpm -q fakepackage
package fakepackage is not installed
```