### PR TITLE
feat: only update repos when needed

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -71,15 +71,19 @@ define packagecloud::repo(
           }
 
           exec { "apt_key_add_${normalized_name}":
-            command => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
-            path    => '/usr/bin/:/bin/',
-            require => File[$normalized_name],
+            command     => "wget --auth-no-challenge -qO - ${base_url}/${repo_name}/gpgkey | apt-key add -",
+            path        => '/usr/bin/:/bin/',
+            require     => File[$normalized_name],
+            subscribe   => File[$normalized_name],
+            refreshonly => true
           }
 
           exec { "apt_get_update_${normalized_name}":
-            command =>  "apt-get update -o Dir::Etc::sourcelist=\"sources.list.d/${normalized_name}.list\" -o Dir::Etc::sourceparts=\"-\" -o APT::Get::List-Cleanup=\"0\"",
-            path    => '/usr/bin/:/bin/',
-            require => Exec["apt_key_add_${normalized_name}"],
+            command     =>  "apt-get update -o Dir::Etc::sourcelist=\"sources.list.d/${normalized_name}.list\" -o Dir::Etc::sourceparts=\"-\" -o APT::Get::List-Cleanup=\"0\"",
+            path        => '/usr/bin/:/bin/',
+            require     => Exec["apt_key_add_${normalized_name}"],
+            subscribe   => Exec["apt_key_add_${normalized_name}"],
+            refreshonly => true
           }
         }
         default: {
@@ -139,9 +143,11 @@ define packagecloud::repo(
           }
 
           exec { "yum_make_cache_${repo_name}":
-            command => "yum -q makecache -y --disablerepo='*' --enablerepo='${normalized_name}'",
-            path    => '/usr/bin',
-            require => File[$normalized_name],
+            command     => "yum -q makecache -y --disablerepo='*' --enablerepo='${normalized_name}'",
+            path        => '/usr/bin',
+            require     => File[$normalized_name],
+            subscribe   => File[$normalized_name],
+            refreshonly => true
           }
         }
 


### PR DESCRIPTION
We have noticed in our Ubuntu systems that apt_get_add and apt_get_update are triggered on every puppet run.

This PR makes them run only whenever there is a change on the .list file